### PR TITLE
Environment variable to determine number of worker processes

### DIFF
--- a/lib/unicorn/rails.rb
+++ b/lib/unicorn/rails.rb
@@ -11,12 +11,9 @@ module Rack
     class Unicorn
       class << self
         def run(app, options = {})
-          workers = ENV['UNICORN_WORKERS'].to_i
-          workers = 1 if workers == 0
-
           unicorn_options = {}
           unicorn_options[:listeners] = ["#{options[:Host]}:#{options[:Port]}"]
-          unicorn_options[:worker_processes] = workers 
+          unicorn_options[:worker_processes] = (ENV["UNICORN_WORKERS"] || "1").to_i
           unicorn_options[:timeout] = 31 * 24 * 60 * 60
 
           ::Unicorn::Launcher.daemonize!(unicorn_options) if options[:daemonize]


### PR DESCRIPTION
I ran into a few occasions where I wanted to spin up more worker processes on my development machine. I liked the simplicity of `unicorn-rails` but I really wanted some way of doing lightweight configuration.

I've been on an "environment as configuration" kick thanks to Heroku so I figured I'd implement worker count that way.
### Usage

Spins up 2 worker processes.

``` bash
$ UNICORN_WORKERS=2 rails server
```

Still works.

``` bash
$ rails server
```
