### PR TITLE
Allow loading of custom unicorn config

### DIFF
--- a/lib/unicorn/rails.rb
+++ b/lib/unicorn/rails.rb
@@ -16,12 +16,16 @@ module Rack
           unicorn_options[:worker_processes] = (ENV["UNICORN_WORKERS"] || "1").to_i
           unicorn_options[:timeout] = 31 * 24 * 60 * 60
 
-          if ::File.exist?("config/unicorn/#{ENV["RAILS_ENV"]}.rb")
-            unicorn_options[:config_file] = "config/unicorn/#{ENV["RAILS_ENV"]}.rb"
+          if ::File.exist?("config/unicorn/#{environment}.rb")
+            unicorn_options[:config_file] = "config/unicorn/#{environment}.rb"
           end
 
           ::Unicorn::Launcher.daemonize!(unicorn_options) if options[:daemonize]
           ::Unicorn::HttpServer.new(app, unicorn_options).start.join
+        end
+
+        def environment
+          ENV['RACK_ENV'] || ENV['RAILS_ENV']
         end
       end
     end


### PR DESCRIPTION
Sometime someone likes to to take advantage of some unicorn goodness thats just available via an own configuration file, though we're checking if theres one for our current environment and loading it.
