### PR TITLE
Only set unicorn options if config file does not exist

### DIFF
--- a/lib/unicorn/rails.rb
+++ b/lib/unicorn/rails.rb
@@ -11,13 +11,16 @@ module Rack
     class Unicorn
       class << self
         def run(app, options = {})
-          unicorn_options = {}
-          unicorn_options[:listeners] = ["#{options[:Host]}:#{options[:Port]}"]
-          unicorn_options[:worker_processes] = (ENV["UNICORN_WORKERS"] || "1").to_i
-          unicorn_options[:timeout] = 31 * 24 * 60 * 60
-
           if ::File.exist?("config/unicorn/#{environment}.rb")
-            unicorn_options[:config_file] = "config/unicorn/#{environment}.rb"
+            unicorn_options = {
+              :config_file => "config/unicorn/#{environment}.rb"
+            }
+          else
+            unicorn_options = {
+              :listeners => ["#{options[:Host]}:#{options[:Port]}"],
+              :worker_processes => (ENV["UNICORN_WORKERS"] || "1").to_i,
+              :timeout => 31 * 24 * 60 * 60
+            }
           end
 
           ::Unicorn::Launcher.daemonize!(unicorn_options) if options[:daemonize]


### PR DESCRIPTION
If there exists a config file, then it seems likely will/should specify the listener, worker_processes, and timeout settings (among other settings).
