### PR TITLE
Inherit host and port from `rails server`

### DIFF
--- a/lib/unicorn_rails.rb
+++ b/lib/unicorn_rails.rb
@@ -10,16 +10,23 @@ module Rack
     class Unicorn
       class << self
         def run(app, options = {})
-          unicorn_options = {}
+          unicorn_options = {
+            :listeners => ["#{options[:Host]}:#{options[:Port]}"]
+          }
 
           if ::File.exist?("config/unicorn/#{environment}.rb")
             unicorn_options[:config_file] = "config/unicorn/#{environment}.rb"
           elsif ::File.exist?("config/unicorn.rb")
             unicorn_options[:config_file] = "config/unicorn.rb"
           else
-            unicorn_options[:listeners] = ["#{options[:Host]}:#{options[:Port]}"]
             unicorn_options[:timeout] = 31 * 24 * 60 * 60
             unicorn_options[:worker_processes] = (ENV["UNICORN_WORKERS"] || "1").to_i
+          end
+
+          if unicorn_options[:config_file]
+            if ::File.read(unicorn_options[:config_file]) =~ /^(\s+)listen\s/
+              unicorn_options.delete(:listeners)
+            end
           end
 
           ::Unicorn::Launcher.daemonize!(unicorn_options) if options[:daemonize]


### PR DESCRIPTION
This makes it so that it will tries to use the defaults given by Rails when user doesn't have `listen` configuration in their `unicorn.rb`.

Before this patch:

=> No `listen` in `config/unicorn.rb`

```
$ rails server
=> Booting Unicorn
=> Rails 4.1.5 application starting in development on http://0.0.0.0:3000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
I, [2014-09-02T22:06:46.940472 #66762]  INFO -- : listening on addr=0.0.0.0:8080 fd=11

$ rails server -p 3001
=> Booting Unicorn
=> Rails 4.1.5 application starting in development on http://0.0.0.0:3001
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
I, [2014-09-02T22:06:46.940472 #66762]  INFO -- : listening on addr=0.0.0.0:8080 fd=11
```

=> With `listen 5000` in `config/unicorn.rb`

```
$ rails server
=> Booting Unicorn
=> Rails 4.1.5 application starting in development on http://0.0.0.0:3000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
I, [2014-09-02T22:06:46.940472 #66762]  INFO -- : listening on addr=0.0.0.0:5000 fd=11

$ rails server -p 3001
=> Booting Unicorn
=> Rails 4.1.5 application starting in development on http://0.0.0.0:3001
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
I, [2014-09-02T22:06:46.940472 #66762]  INFO -- : listening on addr=0.0.0.0:5000 fd=11
```

After this patch:

=> No `listen` in `config/unicorn.rb`

```
$ rails server
=> Booting Unicorn
=> Rails 4.1.5 application starting in development on http://0.0.0.0:3000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
I, [2014-09-02T22:06:46.940472 #66762]  INFO -- : listening on addr=0.0.0.0:3000 fd=11

$ rails server -p 3001
=> Booting Unicorn
=> Rails 4.1.5 application starting in development on http://0.0.0.0:3001
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
I, [2014-09-02T22:06:46.940472 #66762]  INFO -- : listening on addr=0.0.0.0:3001 fd=11
```

=> With `listen 5000` in `config/unicorn.rb`

```
$ rails server
=> Booting Unicorn
=> Rails 4.1.5 application starting in development on http://0.0.0.0:3000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
I, [2014-09-02T22:06:46.940472 #66762]  INFO -- : listening on addr=0.0.0.0:5000 fd=11

$ rails server -p 3001
=> Booting Unicorn
=> Rails 4.1.5 application starting in development on http://0.0.0.0:3001
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
I, [2014-09-02T22:06:46.940472 #66762]  INFO -- : listening on addr=0.0.0.0:5000 fd=11
```

Note that it might looks weird for the last case, but that's an expected outcome given user overrides `config/unicorn.rb` themselves.

Fixes #9
