### PR TITLE
Add license to gemspec

### DIFF
--- a/unicorn-rails.gemspec
+++ b/unicorn-rails.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |gem|
   gem.summary     = readme.summary
   gem.homepage    = "https://github.com/samuelkadolph/unicorn-rails"
   gem.version     = UnicornRails::VERSION
+  gem.license     = "MIT"
 
   gem.files       = Dir["lib/**/*"]
 


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.